### PR TITLE
swap out bip39, swap in dashphrase, fix recovery phrase bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ OPTIONS:
 
 ```sh
 # wallet contact <handle> [xpub-or-addr]
+wallet contact @johndoe 'xpubXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
 wallet contact @kraken 'Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
 ```
 
@@ -94,7 +95,7 @@ Wallet.generate({
   "device": null,
   "contact": null,
   "priority": 1,
-  "mnemonic": ["twelve", "words"],
+  "phrase": "zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong",
   "created_at": "2022-02-22T22:02:22.000Z",
   "archived_at": null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,8 @@
         "@dashincubator/secp256k1": "^1.7.1-5",
         "@pinojs/json-colorizer": "^3.0.0",
         "@root/base58check": "^1.0.1",
-        "@root/passphrase": "^1.1.0",
-        "bip39": "^3.0.4",
         "dashhd": "^3.0.5",
+        "dashphrase": "^1.3.9",
         "dashsight": "^1.5.0",
         "dotenv": "^16.0.3",
         "ripemd160": "^2.0.2",
@@ -87,33 +86,12 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
-    "node_modules/@root/passphrase": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@root/passphrase/-/passphrase-1.1.0.tgz",
-      "integrity": "sha512-uokMKGQ+wUiqHpvxWRZNj5QtSGvoLOfOND/ny7NZaV2+48mahzJPUbLE9y/xhf/536mi9UvwlnbgTyVqedVHUA=="
-    },
-    "node_modules/@types/node": {
-      "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-    },
     "node_modules/base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
       "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
-      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
-      "dependencies": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
       }
     },
     "node_modules/bloom-filter": {
@@ -144,44 +122,10 @@
         "base-x": "^3.0.2"
       }
     },
-    "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "node_modules/colorette": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
     },
     "node_modules/dashhd": {
       "version": "3.0.5",
@@ -195,6 +139,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dashkeys/-/dashkeys-1.0.0.tgz",
       "integrity": "sha512-Ph3wlQEJUEYTSqBMVxIR/MuO9L2aIccvglTsB7Kws1ARPt1wW4iyNUT8axY954+ZqSNqVQKj7TSxxLe/IA/Q5w=="
+    },
+    "node_modules/dashphrase": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/dashphrase/-/dashphrase-1.3.9.tgz",
+      "integrity": "sha512-Hh1LEoiNxp63DGCeWLauoHbDeVyE7xzOZhMNFGdiq0HDaQt1Zkq0kJ9yhiQj7Dq3rZrAPybGM0xkI8/wqY3+ig=="
     },
     "node_modules/dashsight": {
       "version": "1.5.0",
@@ -286,16 +235,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -319,29 +258,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
-      "dependencies": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/readable-stream": {
@@ -397,18 +313,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      },
-      "bin": {
-        "sha.js": "bin.js"
       }
     },
     "node_modules/string_decoder": {
@@ -497,33 +401,12 @@
         }
       }
     },
-    "@root/passphrase": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@root/passphrase/-/passphrase-1.1.0.tgz",
-      "integrity": "sha512-uokMKGQ+wUiqHpvxWRZNj5QtSGvoLOfOND/ny7NZaV2+48mahzJPUbLE9y/xhf/536mi9UvwlnbgTyVqedVHUA=="
-    },
-    "@types/node": {
-      "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-    },
     "base-x": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
       "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
       "requires": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "bip39": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
-      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
-      "requires": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
       }
     },
     "bloom-filter": {
@@ -554,44 +437,10 @@
         "base-x": "^3.0.2"
       }
     },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "colorette": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
     },
     "dashhd": {
       "version": "3.0.5",
@@ -605,6 +454,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dashkeys/-/dashkeys-1.0.0.tgz",
       "integrity": "sha512-Ph3wlQEJUEYTSqBMVxIR/MuO9L2aIccvglTsB7Kws1ARPt1wW4iyNUT8axY954+ZqSNqVQKj7TSxxLe/IA/Q5w=="
+    },
+    "dashphrase": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/dashphrase/-/dashphrase-1.3.9.tgz",
+      "integrity": "sha512-Hh1LEoiNxp63DGCeWLauoHbDeVyE7xzOZhMNFGdiq0HDaQt1Zkq0kJ9yhiQj7Dq3rZrAPybGM0xkI8/wqY3+ig=="
     },
     "dashsight": {
       "version": "1.5.0",
@@ -678,16 +532,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -707,26 +551,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
       "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
-    },
-    "pbkdf2": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "readable-stream": {
       "version": "3.6.0",
@@ -760,15 +584,6 @@
         "elliptic": "^6.5.4",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
-      }
-    },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashwallet",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashwallet",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@dashevo/dashcore-lib": "^0.19.44",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,9 @@
     "@dashincubator/secp256k1": "^1.7.1-5",
     "@pinojs/json-colorizer": "^3.0.0",
     "@root/base58check": "^1.0.1",
-    "@root/passphrase": "^1.1.0",
-    "dashsight": "^1.5.0",
-    "bip39": "^3.0.4",
     "dashhd": "^3.0.5",
+    "dashphrase": "^1.3.9",
+    "dashsight": "^1.5.0",
     "dotenv": "^16.0.3",
     "ripemd160": "^2.0.2",
     "secp256k1": "^4.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashwallet",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A more civilized wallet for a less civilized age",
   "main": "index.js",
   "bin": {

--- a/wallet.js
+++ b/wallet.js
@@ -307,7 +307,7 @@
         }
 
         if ("*" === addrInfo.hdpath) {
-          // ignore
+          // ignore wifs
         }
 
         let b = addrInfo.utxos.reduce(
@@ -396,7 +396,7 @@
         }
 
         if ("*" === addrInfo.hdpath) {
-          // ignore
+          // ignore wifs
         }
 
         addrInfo.utxos.forEach(
@@ -1056,6 +1056,13 @@
         w,
       ) {
         await promise;
+
+        if (w.wifs) {
+          for (let wifInfo of w.wifs) {
+            await indexWifAddr(wifInfo.addr, now, staletime);
+          }
+          await config.store.save(safe.privateWallets);
+        }
 
         let mnemonic = w.mnemonic.join(" ");
         // TODO use derivation from main for non-imported wallets


### PR DESCRIPTION
- bump minor pre-release version (has transitional, but otherwise breaking changes)
- replace `bip39` (not browser-compatible) with `dashphrase`
- replace mnemonic arrays `["zoo", "zoo", ...]` with phrase strings `"zoo zoo ..."`
- bugfix check for loose WIFs during sync
- bugfix recovery phrases were not being checked
- bugfix malformed empty recovery phrases existed
- minor doc updates