### PR TITLE
ref: externalize storage from legacy tx functions

### DIFF
--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1875,10 +1875,20 @@
       let totalAvailable = DashApi.getBalance(inputs);
       let fees = DashTx.appraise({ inputs: inputs, outputs: [output] });
 
+      //let EXTRA_SIG_BYTES_PER_INPUT = 2;
+      let CHANCE_INPUT_SIGS_HAVE_NO_EXTRA_BYTES = 1 / 4;
+      let MINIMUM_CHANCE_SIG_MATCHES_TARGET = 1 / 20;
+
       let feeEstimate = fees.min;
-      let minimumIsUnlikely = inputs.length > 2;
+      let chanceSignaturesMatchLowestFee = Math.pow(
+        CHANCE_INPUT_SIGS_HAVE_NO_EXTRA_BYTES,
+        inputs.length,
+      );
+      let minimumIsUnlikely =
+        chanceSignaturesMatchLowestFee < MINIMUM_CHANCE_SIG_MATCHES_TARGET;
       if (minimumIsUnlikely) {
-        let likelyPadByteSize = 2 * inputs.length;
+        //let likelyPadByteSize = EXTRA_SIG_BYTES_PER_INPUT * inputs.length;
+        let likelyPadByteSize = inputs.length;
         feeEstimate += likelyPadByteSize;
       }
 

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1412,7 +1412,7 @@
       // TODO try first to hit the target output values
       if (!inputs) {
         let utxos = wallet.utxos();
-        inputs = mustSelectInputs({
+        inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: satoshis,
         });
@@ -1683,7 +1683,7 @@
     }) {
       if (!inputs) {
         let utxos = wallet.utxos();
-        inputs = mustSelectInputs({
+        inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: satoshis,
         });
@@ -1779,7 +1779,7 @@
     }) {
       if (!inputs) {
         let utxos = wallet.utxos();
-        inputs = mustSelectInputs({
+        inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: output.satoshis,
         });
@@ -1866,28 +1866,6 @@
       await wallet._authDirtyTx({ summary, now });
       return summary;
     };
-
-    /**
-     * @param {Object} opts
-     * @param {Array<CoreUtxo>} opts.utxos
-     * @param {Number} [opts.satoshis]
-     * @param {Number} [opts.now] - ms
-     */
-    function mustSelectInputs({ utxos, satoshis }) {
-      if (!satoshis) {
-        let msg = `expected target selection value 'satoshis' to be a positive integer but got '${satoshis}'`;
-        let err = new Error(msg);
-        throw err;
-      }
-
-      let selected = DashApi.selectOptimalUtxos(utxos, satoshis);
-
-      if (!selected.length) {
-        throw Wallet._createInsufficientFundsError(utxos, satoshis);
-      }
-
-      return selected;
-    }
 
     /**
      * @param {Object} opts
@@ -2771,6 +2749,28 @@
       `insufficient funds: cannot pay ${dashAmount} (+${feeAmount} fee) with ${dashBalance}`,
     );
     throw err;
+  };
+
+  /**
+   * @param {Object} opts
+   * @param {Array<CoreUtxo>} opts.utxos
+   * @param {Number} [opts.satoshis]
+   * @param {Number} [opts.now] - ms
+   */
+  Wallet._mustSelectInputs = function ({ utxos, satoshis }) {
+    if (!satoshis) {
+      let msg = `expected target selection value 'satoshis' to be a positive integer but got '${satoshis}'`;
+      let err = new Error(msg);
+      throw err;
+    }
+
+    let selected = DashApi.selectOptimalUtxos(utxos, satoshis);
+
+    if (!selected.length) {
+      throw Wallet._createInsufficientFundsError(utxos, satoshis);
+    }
+
+    return selected;
   };
 
   /**

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1878,7 +1878,7 @@
       inputs = DashApi.selectOptimalUtxos(coins, satoshis);
 
       if (!inputs.length) {
-        throw createInsufficientFundsError(coins, satoshis);
+        throw Wallet._createInsufficientFundsError(coins, satoshis);
       }
 
       return inputs;
@@ -2039,26 +2039,6 @@
       });
 
       return summary;
-    }
-
-    /**
-     * @param {Array<CoreUtxo>} allInputs
-     * @param {Number} satoshis
-     */
-    function createInsufficientFundsError(allInputs, satoshis) {
-      let totalBalance = DashApi.getBalance(allInputs);
-      let dashBalance = DashApi.toDash(totalBalance);
-      let dashAmount = DashApi.toDash(satoshis);
-      let fees = DashTx.appraise({
-        inputs: allInputs,
-        outputs: [{}],
-      });
-      let feeAmount = DashApi.toDash(fees.mid);
-
-      let err = new Error(
-        `insufficient funds: cannot pay ${dashAmount} (+${feeAmount} fee) with ${dashBalance}`,
-      );
-      throw err;
     }
 
     /**
@@ -2766,6 +2746,26 @@
     }
 
     return wallet;
+  };
+
+  /**
+   * @param {Array<CoreUtxo>} allInputs
+   * @param {Number} satoshis
+   */
+  Wallet._createInsufficientFundsError = function (allInputs, satoshis) {
+    let totalBalance = DashApi.getBalance(allInputs);
+    let dashBalance = DashApi.toDash(totalBalance);
+    let dashAmount = DashApi.toDash(satoshis);
+    let fees = DashTx.appraise({
+      inputs: allInputs,
+      outputs: [{}],
+    });
+    let feeAmount = DashApi.toDash(fees.mid);
+
+    let err = new Error(
+      `insufficient funds: cannot pay ${dashAmount} (+${feeAmount} fee) with ${dashBalance}`,
+    );
+    throw err;
   };
 
   /**

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1919,19 +1919,17 @@
      */
     wallet.legacy.finalizeAndSignTx = async function (txDraft, keys) {
       /** @type {import('dashtx').TxInfoSigned} */
-      let txSigned = await _signToTarget(
-        txDraft,
-        txDraft.feeEstimate,
-        keys,
-      ).catch(async function (e) {
-        //@ts-ignore
-        if ("E_NO_ENTROPY" !== e.code) {
-          throw e;
-        }
+      let txSigned = await _signToTarget(txDraft, keys).catch(
+        async function (e) {
+          //@ts-ignore
+          if ("E_NO_ENTROPY" !== e.code) {
+            throw e;
+          }
 
-        let _txSigned = await _signFeeWalk(txDraft, keys);
-        return _txSigned;
-      });
+          let _txSigned = await _signFeeWalk(txDraft, keys);
+          return _txSigned;
+        },
+      );
 
       let txSummary = _summarizeLegacyTx(txSigned);
       return txSummary;
@@ -2090,41 +2088,39 @@
     }
 
     /**
-     * @param {import('dashtx').TxInfo} txInfoRaw
-     * @param {Number} feeEstimate
+     * @param {TxDraft} txDraft
      * @param {Array<Uint8Array>} keys
+     * @returns {Promise<TxInfoSigned>}
      */
-    async function _signToTarget(txInfoRaw, feeEstimate, keys) {
+    async function _signToTarget(txDraft, keys) {
       let limit = 128;
       let lastTx = "";
       let hasEntropy = true;
 
       /** @type {import('dashtx').TxInfoSigned} */
-      let txInfo;
+      let txSigned;
 
       for (let n = 0; true; n += 1) {
-        txInfo = await dashTx.hashAndSignAll(txInfoRaw, keys);
-        //console.log("DEBUG txInfoRaw (entropy):");
-        //console.log(txInfoRaw);
+        txSigned = await dashTx.hashAndSignAll(txDraft, keys);
 
-        lastTx = txInfo.transaction;
-        let fee = txInfo.transaction.length / 2;
-        if (fee <= feeEstimate) {
+        lastTx = txSigned.transaction;
+        let fee = txSigned.transaction.length / 2;
+        if (fee <= txDraft.feeEstimate) {
           break;
         }
 
-        if (txInfo.transaction === lastTx) {
+        if (txSigned.transaction === lastTx) {
           hasEntropy = false;
           break;
         }
         if (n >= limit) {
           throw new Error(
-            `(near-)infinite loop: fee is ${fee} trying to hit target fee of ${feeEstimate}`,
+            `(near-)infinite loop: fee is ${fee} trying to hit target fee of ${txDraft.feeEstimate}`,
           );
         }
       }
 
-      return txInfo;
+      return txSigned;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dashhd": "^3.3.0",
         "dashphrase": "^1.4.0",
         "dashsight": "^1.6.1",
-        "dashtx": "^0.13.2"
+        "dashtx": "^0.14.1"
       }
     },
     "node_modules/dashhd": {
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/dashtx": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/dashtx/-/dashtx-0.13.2.tgz",
-      "integrity": "sha512-zBs5lqwfB6gxlY2uJ19CA2swMV2EC4Eyi2UizC+/Dha2Z9qvTt/8yYdpmUYEo9RLl4IOG+ZBYSb9zxvAq07IhA==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/dashtx/-/dashtx-0.14.1.tgz",
+      "integrity": "sha512-KqO0IxPsXyYLN25MPsILXtSyi8P9CE42vNrfo2BC+7BumBNzPv7CPZRmzcP693VsFe3V4qPEY2oTa3j0Yo4+rQ==",
       "bin": {
         "dashtx-inspect": "bin/inspect.js"
       }
@@ -113,9 +113,9 @@
       }
     },
     "dashtx": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/dashtx/-/dashtx-0.13.2.tgz",
-      "integrity": "sha512-zBs5lqwfB6gxlY2uJ19CA2swMV2EC4Eyi2UizC+/Dha2Z9qvTt/8yYdpmUYEo9RLl4IOG+ZBYSb9zxvAq07IhA=="
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/dashtx/-/dashtx-0.14.1.tgz",
+      "integrity": "sha512-KqO0IxPsXyYLN25MPsILXtSyi8P9CE42vNrfo2BC+7BumBNzPv7CPZRmzcP693VsFe3V4qPEY2oTa3j0Yo4+rQ=="
     },
     "dotenv": {
       "version": "16.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashwallet",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashwallet",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "dashhd": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashwallet",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A more civilized wallet for a less civilized age",
   "main": "index.js",
   "bin": {},

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "dashhd": "^3.3.0",
     "dashphrase": "^1.4.0",
     "dashsight": "^1.6.1",
-    "dashtx": "^0.13.2"
+    "dashtx": "^0.14.1"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,8 @@ let Fs = require("node:fs/promises");
 let Path = require("node:path");
 
 async function main() {
+  console.info("TAP version 13");
+
   let dirents = await Fs.readdir(__dirname, { withFileTypes: true });
 
   let failures = 0;
@@ -23,13 +25,14 @@ async function main() {
       failures += 1;
     }
   }
-  if (failures === 0) {
-    console.info("# PASS");
-  } else {
-    console.info("# FAIL");
-  }
 
-  console.info("TAP version 13");
+  let passes = count - failures;
+  console.info(``);
+  console.info(`1..${count}`);
+  console.info(`# tests ${count}`);
+  console.info(`# pass  ${passes}`);
+  console.info(`# fail  ${failures}`);
+  console.info(`# skip  0`);
 
   if (failures !== 0) {
     process.exit(1);


### PR DESCRIPTION
This allows using more of the wallet SDK functionality without being dependent on its caching strategy.

Although this results in functions that should probably move to DashTx before v1.0 of DashWallet - it's okay, we're still figuring things out.