### PR TITLE
allow setting the preferred feeSize

### DIFF
--- a/dashwallet.js
+++ b/dashwallet.js
@@ -30,6 +30,7 @@
   /** @typedef {import('dashtx').TxInfo} TxInfoRaw */
   /** @typedef {import('dashtx').TxInfoSigned} TxInfoSigned */
   /** @typedef {import('dashtx').TxOutput} TxOutput */
+  /** @typedef {import('dashtx').TxFees} TxFees */
   /** @typedef {import('dashsight').GetTxs} GetTxs */
   /** @typedef {import('dashsight').GetUtxos} GetUtxos */
   /** @typedef {import('dashsight').InstantSend} InstantSend */
@@ -1844,10 +1845,16 @@
      * @param {Object} opts
      * @param {Array<CoreUtxo>?} [opts.inputs]
      * @param {Array<CoreUtxo>?} [opts.utxos]
-     * @param {import('dashtx').TxOutput} opts.output
+     * @param {TxOutput} opts.output
+     * @param {keyof TxFees} [opts.feeSize]
      * @returns {Promise<TxDraft>}
      */
-    wallet.legacy.draftTx = async function ({ utxos, inputs, output }) {
+    wallet.legacy.draftTx = async function ({
+      utxos,
+      inputs,
+      output,
+      feeSize = 'min',
+    }) {
       let fullTransfer = false;
 
       if (!inputs) {
@@ -1863,7 +1870,7 @@
       let totalAvailable = DashApi.getBalance(inputs);
       let fees = DashTx.appraise({ inputs: inputs, outputs: [output] });
 
-      let feeEstimate = fees.min;
+      let feeEstimate = fees[feeSize];
       let minimumIsUnlikely = inputs.length > 2;
       if (minimumIsUnlikely) {
         let likelyPadByteSize = 2 * inputs.length;

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1868,7 +1868,7 @@
       inputs = DashApi.selectOptimalUtxos(coins, satoshis);
 
       if (!inputs.length) {
-        throw createInsufficientFundsError(coins, satoshis);
+        throw Wallet._createInsufficientFundsError(coins, satoshis);
       }
 
       return inputs;
@@ -2029,26 +2029,6 @@
       });
 
       return summary;
-    }
-
-    /**
-     * @param {Array<CoreUtxo>} allInputs
-     * @param {Number} satoshis
-     */
-    function createInsufficientFundsError(allInputs, satoshis) {
-      let totalBalance = DashApi.getBalance(allInputs);
-      let dashBalance = DashApi.toDash(totalBalance);
-      let dashAmount = DashApi.toDash(satoshis);
-      let fees = DashTx.appraise({
-        inputs: allInputs,
-        outputs: [{}],
-      });
-      let feeAmount = DashApi.toDash(fees.mid);
-
-      let err = new Error(
-        `insufficient funds: cannot pay ${dashAmount} (+${feeAmount} fee) with ${dashBalance}`,
-      );
-      throw err;
     }
 
     /**
@@ -2756,6 +2736,26 @@
     }
 
     return wallet;
+  };
+
+  /**
+   * @param {Array<CoreUtxo>} allInputs
+   * @param {Number} satoshis
+   */
+  Wallet._createInsufficientFundsError = function (allInputs, satoshis) {
+    let totalBalance = DashApi.getBalance(allInputs);
+    let dashBalance = DashApi.toDash(totalBalance);
+    let dashAmount = DashApi.toDash(satoshis);
+    let fees = DashTx.appraise({
+      inputs: allInputs,
+      outputs: [{}],
+    });
+    let feeAmount = DashApi.toDash(fees.mid);
+
+    let err = new Error(
+      `insufficient funds: cannot pay ${dashAmount} (+${feeAmount} fee) with ${dashBalance}`,
+    );
+    throw err;
   };
 
   /**

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -27,11 +27,39 @@
   */
 
   /** @typedef {import('dashsight').CoreUtxo} CoreUtxo */
+  /** @typedef {import('dashtx').TxInfo} TxInfoRaw */
+  /** @typedef {import('dashtx').TxInfoSigned} TxInfoSigned */
   /** @typedef {import('dashtx').TxOutput} TxOutput */
   /** @typedef {import('dashsight').GetTxs} GetTxs */
   /** @typedef {import('dashsight').GetUtxos} GetUtxos */
   /** @typedef {import('dashsight').InstantSend} InstantSend */
   /** @typedef {import('dashsight').InsightUtxo} InsightUtxo */
+
+  /** @typedef {TxInfoRaw & TxDraftPartial} TxDraft */
+  /**
+   * @typedef TxDraftPartial
+   * @prop {TxOutput} change
+   * @prop {Number} feeEstimate
+   * @prop {Boolean} fullTransfer
+   */
+
+  /** @typedef {TxInfoSigned & TxSummaryPartial} TxSummary */
+  /**
+   * @typedef TxSummaryPartial
+   * @prop {Number} total - sum of all inputs
+   * @prop {Number} sent - sum of all outputs
+   * @prop {Number} fee - actual fee
+   * @prop {Array<TxOutput>} outputs
+   * @prop {Array<import('dashtx').TxInput>} inputs
+   * @prop {TxOutput} output - alias of 'recipient' for backwards-compat
+   * @prop {TxOutput} recipient - output to recipient
+   * @prop {TxOutput} change - sent back to self
+   */
+
+  /**
+   * @typedef MaybeHasAddress
+   * @prop {String} [address]
+   */
 
   const DUFFS = 100000000;
   const DUST = 10000;
@@ -1758,21 +1786,78 @@
     // XXX pass in known-good change addrs
     /**
      * @param {Object} opts
-     * @param {Array<CoreUtxo>?} [opts.inputs]
+     * @param {Array<CoreUtxo>?} [opts.utxos] - ALL utxos for the wallet
+     * @param {Array<CoreUtxo>?} [opts.inputs] - selected utxos for this transaction
      * @param {import('dashtx').TxOutput} opts.output
      * @param {Number} [opts.now] - ms
      */
     wallet.createDirtyTx = async function ({
+      utxos,
       inputs,
       output,
       now = Date.now(),
     }) {
+      if (!utxos?.length) {
+        utxos = wallet.utxos();
+      }
+
+      let txDraft = await wallet.legacy.draftTx({ utxos, inputs, output });
+
+      if (txDraft.change) {
+        let count = 1;
+        let handle = "main";
+        let account = 0; // main
+        let usage = 1;
+
+        let hdpath = `m/44'/${COIN_TYPE}'/${account}'/${usage}`;
+        let xKey = await wallet._recoverXPrv({ handle, hdpath });
+
+        // TODO should be name, not handle (though they're the same for main)
+        let offset = await indexPayAddrs(handle, xKey, hdpath, now);
+        await config.store.save(safe.cache);
+
+        let addrs = await wallet._nextWalletAddrs({ xKey, offset, count });
+
+        txDraft.change.address = addrs[0];
+      }
+
+      for (let output of txDraft.outputs) {
+        //@ts-ignore TODO bad export
+        let pkh = await DashKeys.addrToPkh(output.address);
+        //@ts-ignore TODO bad export
+        let pkhHex = DashKeys.utils.bytesToHex(pkh);
+        Object.assign(output, { pubKeyHash: pkhHex });
+      }
+
+      let keys = await wallet._utxosToPrivKeys(txDraft.inputs);
+
+      let txSummary = await wallet.legacy.finalizeAndSignTx(txDraft, keys);
+
+      await wallet._authDirtyTx({ summary: txSummary, now: now });
+
+      return txSummary;
+    };
+
+    wallet.legacy = {};
+
+    /**
+     * @param {Object} opts
+     * @param {Array<CoreUtxo>?} [opts.inputs]
+     * @param {Array<CoreUtxo>?} [opts.utxos]
+     * @param {import('dashtx').TxOutput} opts.output
+     * @returns {Promise<TxDraft>}
+     */
+    wallet.legacy.draftTx = async function ({ utxos, inputs, output }) {
+      let fullTransfer = false;
+
       if (!inputs) {
-        let utxos = wallet.utxos();
+        utxos = wallet.utxos();
         inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: output.satoshis,
         });
+      } else {
+        fullTransfer = !output.satoshis;
       }
 
       let totalAvailable = DashApi.getBalance(inputs);
@@ -1797,21 +1882,6 @@
       let hasChange = change.satoshis > DashApi.DUST;
 
       if (hasChange) {
-        let count = 1;
-        let handle = "main";
-        let account = 0; // main
-        let usage = 1;
-
-        let hdpath = `m/44'/${COIN_TYPE}'/${account}'/${usage}`;
-        let xKey = await wallet._recoverXPrv({ handle, hdpath });
-
-        // TODO should be name, not handle (though they're the same for main)
-        let offset = await indexPayAddrs(handle, xKey, hdpath, now);
-        await config.store.save(safe.cache);
-
-        let addrs = await wallet._nextWalletAddrs({ xKey, offset, count });
-
-        change.address = addrs[0];
         outputs.push(change);
         feeEstimate += DashTx.OUTPUT_SIZE;
       } else {
@@ -1819,54 +1889,45 @@
         feeEstimate = totalAvailable + -recip.satoshis;
       }
 
-      for (let output of outputs) {
-        //@ts-ignore TODO bad export
-        let pkh = await DashKeys.addrToPkh(output.address);
-        //@ts-ignore TODO bad export
-        let pkhHex = DashKeys.utils.bytesToHex(pkh);
-        Object.assign(output, { pubKeyHash: pkhHex });
-      }
-
       let txInfoRaw = {
-        inputs: inputs,
-        outputs: outputs,
+        inputs,
+        outputs,
+        change,
+        feeEstimate,
+        fullTransfer,
       };
-      let keys = await wallet._utxosToPrivKeys(inputs);
 
+      return txInfoRaw;
+    };
+
+    /**
+     * @param {TxDraft} txDraft
+     * @param {Array<Uint8Array>} keys
+     * @returns {Promise<TxSummary>}
+     */
+    wallet.legacy.finalizeAndSignTx = async function (txDraft, keys) {
       /** @type {import('dashtx').TxInfoSigned} */
-      let txInfo = await _signToTarget(txInfoRaw, feeEstimate, keys).catch(
-        async function (e) {
-          //@ts-ignore
-          if ("E_NO_ENTROPY" !== e.code) {
-            throw e;
-          }
-          let txInfo = await _signFeeWalk(
-            txInfoRaw,
-            output,
-            feeEstimate,
-            change,
-            keys,
-          );
-          return txInfo;
-        },
-      );
+      let txSigned = await _signToTarget(
+        txDraft,
+        txDraft.feeEstimate,
+        keys,
+      ).catch(async function (e) {
+        //@ts-ignore
+        if ("E_NO_ENTROPY" !== e.code) {
+          throw e;
+        }
 
-      let summary = summarizeDirtyTx(txInfo);
-      //@ts-ignore TODO type summary
-      await wallet._authDirtyTx({ summary, now });
-      return summary;
+        let _txSigned = await _signFeeWalk(txDraft, keys);
+        return _txSigned;
+      });
+
+      let txSummary = _summarizeLegacyTx(txSigned);
+      return txSummary;
     };
 
     /**
      * @param {Object} opts
-     * @param {Object} opts.summary
-     * @param {Object} opts.summary.output
-     * @param {String} [opts.summary.output.address]
-     * @param {Number} [opts.summary.output.satoshis]
-     * @param {Object} [opts.summary.change]
-     * @param {String} [opts.summary.change.address]
-     * @param {Number} [opts.summary.change.satoshis]
-     * @param {Array<CoreUtxo>?} [opts.summary.inputs]
+     * @param {TxSummary} opts.summary
      * @param {Number} [opts.now] - ms
      */
     wallet._authDirtyTx = async function ({ summary, now = Date.now() }) {
@@ -1977,9 +2038,10 @@
     }
 
     /**
-     * @param {import('dashtx').TxInfoSigned} txInfo
+     * @param {TxInfoSigned} txInfo
+     * @returns {TxSummary}
      */
-    function summarizeDirtyTx(txInfo) {
+    function _summarizeLegacyTx(txInfo) {
       let totalAvailable = 0;
       for (let coin of txInfo.inputs) {
         //@ts-ignore - our inputs are mixed with CoreUtxo
@@ -2002,14 +2064,15 @@
       }
       fee -= changeSats;
 
-      let summary = Object.assign(txInfo, {
+      let summaryPartial = {
         total: totalAvailable,
         sent: sent,
         fee: fee,
         output: recipient,
         recipient: recipient,
         change: change,
-      });
+      };
+      let summary = Object.assign({}, txInfo, summaryPartial);
 
       return summary;
     }
@@ -2053,25 +2116,22 @@
     }
 
     /**
-     * @param {import('dashtx').TxInfo} txInfoRaw
-     * @param {Object} output
-     * @param {Number} [output.satoshis]
-     * @param {Number} feeEstimate
-     * @param {Object} change
-     * @param {Number} change.satoshis
+     * Strategy for signing transactions when a non-entropy signing method is used -
+     * exhaustively walk each possible signature until one that works is found.
+     * @param {TxDraft} txDraft
      * @param {Array<Uint8Array>} keys
+     * @returns {Promise<TxInfoSigned>}
      */
-    async function _signFeeWalk(txInfoRaw, output, feeEstimate, change, keys) {
-      let fees = DashTx.appraise(txInfoRaw);
-      let limit = fees.max - feeEstimate;
+    async function _signFeeWalk(txDraft, keys) {
+      let fees = DashTx.appraise(txDraft);
+      let limit = fees.max - txDraft.feeEstimate;
 
-      /** @type {import('dashtx').TxInfoSigned} */
-      let txInfo;
+      /** @type TxInfoSigned */
+      let txSigned;
 
       for (let n = 0; true; n += 1) {
-        let isTransfer = !output.satoshis;
-        let hasExtra = change.satoshis > 0;
-        let canIncreaseFee = isTransfer || hasExtra;
+        let hasChange = txDraft.change?.satoshis > 0;
+        let canIncreaseFee = txDraft.fullTransfer || hasChange;
         if (!canIncreaseFee) {
           // TODO try to add another utxo before failing
           throw new Error(
@@ -2080,30 +2140,26 @@
         }
 
         let outIndex = 0;
-        if (hasExtra) {
-          outIndex = txInfoRaw.outputs.length - 1;
-          change.satoshis -= 1;
+        if (hasChange) {
+          outIndex = txDraft.outputs.length - 1;
         }
-        txInfoRaw.outputs[outIndex].satoshis -= 1;
+        txDraft.outputs[outIndex].satoshis -= 1;
 
-        txInfo = await dashTx.hashAndSignAll(txInfoRaw, keys);
+        txSigned = await dashTx.hashAndSignAll(txDraft, keys);
 
-        //console.log("DEBUG txInfoRaw (walk fee):");
-        //console.log(txInfoRaw);
-
-        let fee = txInfo.transaction.length / 2;
-        if (fee <= feeEstimate) {
+        let fee = txSigned.transaction.length / 2;
+        if (fee <= txDraft.feeEstimate) {
           break;
         }
 
         if (n >= limit) {
           throw new Error(
-            `(near-)infinite loop: fee is ${fee} trying to hit target fee of ${feeEstimate}`,
+            `(near-)infinite loop: fee is ${fee} trying to hit target fee of ${txDraft.feeEstimate}`,
           );
         }
       }
 
-      return txInfo;
+      return txSigned;
     }
 
     // TODO nix
@@ -2140,7 +2196,7 @@
     };
 
     /**
-     * @param {Array<CoreUtxo>} utxos
+     * @param {Array<MaybeHasAddress>} utxos
      * @returns {Promise<Array<Uint8Array>>} - wifs
      */
     wallet._utxosToPrivKeys = async function (utxos) {
@@ -2151,6 +2207,11 @@
 
       await utxos.reduce(async function (promise, utxo) {
         await promise;
+
+        if (!utxo.address) {
+          let msg = `'address' must be assigned before attempting to retrieve private key`;
+          throw new Error(msg);
+        }
 
         let wifInfo = await wallet.findWif({
           address: utxo.address,

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1400,7 +1400,7 @@
       // TODO try first to hit the target output values
       if (!inputs) {
         let utxos = wallet.utxos();
-        inputs = mustSelectInputs({
+        inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: satoshis,
         });
@@ -1673,7 +1673,7 @@
     }) {
       if (!inputs) {
         let utxos = wallet.utxos();
-        inputs = mustSelectInputs({
+        inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: satoshis,
         });
@@ -1769,7 +1769,7 @@
     }) {
       if (!inputs) {
         let utxos = wallet.utxos();
-        inputs = mustSelectInputs({
+        inputs = Wallet._mustSelectInputs({
           utxos: utxos,
           satoshis: output.satoshis,
         });
@@ -1856,28 +1856,6 @@
       await wallet._authDirtyTx({ summary, now });
       return summary;
     };
-
-    /**
-     * @param {Object} opts
-     * @param {Array<CoreUtxo>} opts.utxos
-     * @param {Number} [opts.satoshis]
-     * @param {Number} [opts.now] - ms
-     */
-    function mustSelectInputs({ utxos, satoshis }) {
-      if (!satoshis) {
-        let msg = `expected target selection value 'satoshis' to be a positive integer but got '${satoshis}'`;
-        let err = new Error(msg);
-        throw err;
-      }
-
-      let selected = DashApi.selectOptimalUtxos(utxos, satoshis);
-
-      if (!selected.length) {
-        throw Wallet._createInsufficientFundsError(utxos, satoshis);
-      }
-
-      return selected;
-    }
 
     /**
      * @param {Object} opts
@@ -2761,6 +2739,28 @@
       `insufficient funds: cannot pay ${dashAmount} (+${feeAmount} fee) with ${dashBalance}`,
     );
     throw err;
+  };
+
+  /**
+   * @param {Object} opts
+   * @param {Array<CoreUtxo>} opts.utxos
+   * @param {Number} [opts.satoshis]
+   * @param {Number} [opts.now] - ms
+   */
+  Wallet._mustSelectInputs = function ({ utxos, satoshis }) {
+    if (!satoshis) {
+      let msg = `expected target selection value 'satoshis' to be a positive integer but got '${satoshis}'`;
+      let err = new Error(msg);
+      throw err;
+    }
+
+    let selected = DashApi.selectOptimalUtxos(utxos, satoshis);
+
+    if (!selected.length) {
+      throw Wallet._createInsufficientFundsError(utxos, satoshis);
+    }
+
+    return selected;
   };
 
   /**

--- a/dashwallet.js
+++ b/dashwallet.js
@@ -1398,11 +1398,14 @@
       staletime,
     }) {
       // TODO try first to hit the target output values
-      inputs = mustSelectInputs({
-        inputs: inputs,
-        satoshis: satoshis,
-        now: now,
-      });
+      if (!inputs) {
+        let utxos = wallet.utxos();
+        inputs = mustSelectInputs({
+          utxos: utxos,
+          satoshis: satoshis,
+        });
+      }
+
       let fauxTxos = inputs;
       //let fauxTxos = await inputListToFauxTxos(wallet, inputList);
       let balance = Wallet.getBalance(fauxTxos);
@@ -1668,7 +1671,13 @@
       forceDonation = -1,
       now = Date.now(),
     }) {
-      inputs = mustSelectInputs({ inputs, satoshis, now });
+      if (!inputs) {
+        let utxos = wallet.utxos();
+        inputs = mustSelectInputs({
+          utxos: utxos,
+          satoshis: satoshis,
+        });
+      }
 
       let totalAvailable = DashApi.getBalance(inputs);
       let fees = DashTx.appraise({ inputs: inputs, outputs: [] });
@@ -1758,11 +1767,13 @@
       output,
       now = Date.now(),
     }) {
-      inputs = mustSelectInputs({
-        inputs: inputs,
-        satoshis: output.satoshis,
-        now: now,
-      });
+      if (!inputs) {
+        let utxos = wallet.utxos();
+        inputs = mustSelectInputs({
+          utxos: utxos,
+          satoshis: output.satoshis,
+        });
+      }
 
       let totalAvailable = DashApi.getBalance(inputs);
       let fees = DashTx.appraise({ inputs: inputs, outputs: [output] });
@@ -1848,30 +1859,24 @@
 
     /**
      * @param {Object} opts
-     * @param {Array<CoreUtxo>?} [opts.inputs]
+     * @param {Array<CoreUtxo>} opts.utxos
      * @param {Number} [opts.satoshis]
      * @param {Number} [opts.now] - ms
      */
-    function mustSelectInputs({ inputs, satoshis, now = Date.now() }) {
-      if (inputs) {
-        return inputs;
-      }
-
-      let fullTransfer = !satoshis;
-      if (fullTransfer) {
-        let msg = `'satoshis' must be a positive number unless 'inputs' are specified`;
+    function mustSelectInputs({ utxos, satoshis }) {
+      if (!satoshis) {
+        let msg = `expected target selection value 'satoshis' to be a positive integer but got '${satoshis}'`;
         let err = new Error(msg);
         throw err;
       }
 
-      let coins = wallet.utxos();
-      inputs = DashApi.selectOptimalUtxos(coins, satoshis);
+      let selected = DashApi.selectOptimalUtxos(utxos, satoshis);
 
-      if (!inputs.length) {
-        throw Wallet._createInsufficientFundsError(coins, satoshis);
+      if (!selected.length) {
+        throw Wallet._createInsufficientFundsError(utxos, satoshis);
       }
 
-      return inputs;
+      return selected;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashwallet",
-  "version": "0.6.1",
+  "version": "0.7.0-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashwallet",
-      "version": "0.6.1",
+      "version": "0.7.0-1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "dashhd": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashwallet",
-  "version": "0.6.1",
+  "version": "0.7.0-1",
   "description": "A more civilized wallet for a less civilized age",
   "main": "index.js",
   "bin": {},


### PR DESCRIPTION
When sending a very small amount `0.0001` as a full transfer, Dash Insight API failed with a 400 complaining the fee of 191 was less than the minimum 192.

This allows overriding the default selected fee from `fee.min` (191) to `fee[feeSize]`.

`feeSize` can be a string value of `min`, `mid`, or `max` corresponding to the values returned by `DashTx.appraise(...)`

```js
let txDraft = await dashwallet.legacy.draftTx({
  utxos,
  inputs,
  output,
  feeSize: 'max',
})
```